### PR TITLE
Add OB agent module for OpenAI interactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ __pycache__/
 
 # .gitignore
 .env
+
+# Logs
+logs/

--- a/fracmaster_toolbox/ob_agent/README.md
+++ b/fracmaster_toolbox/ob_agent/README.md
@@ -1,0 +1,18 @@
+# OB Agent
+
+This module manages OB's prompts and interactions with OpenAI's API.
+
+## How it works
+- `ob_client.py` exposes the `OB` class which loads the API key from a `.env` file,
+  initialises the OpenAI client, and logs all requests and responses to
+  `logs/ob_agent.log`.
+- `ob_prompts.py` stores reusable prompts and role definitions.
+- `ob_runner.py` provides a simple CLI for sending prompts to OB.
+
+## Adding new prompts
+Update `ob_prompts.py` and append a new entry to the `ROLE_PROMPTS` dictionary.
+Use `OB.set_role("your_role")` to activate the new role.
+
+## Running tests
+1. Create a `.env` file with `OPENAI_API_KEY=<your key>`.
+2. Run `python scripts/test_ob_agent.py` to send a test prompt to OB.

--- a/fracmaster_toolbox/ob_agent/__init__.py
+++ b/fracmaster_toolbox/ob_agent/__init__.py
@@ -1,0 +1,5 @@
+"""OB agent package for managing prompts and OpenAI interactions."""
+
+from .ob_client import OB
+
+__all__ = ["OB"]

--- a/fracmaster_toolbox/ob_agent/ob_client.py
+++ b/fracmaster_toolbox/ob_agent/ob_client.py
@@ -1,0 +1,57 @@
+"""Client wrapper and OB class for interacting with OpenAI's API."""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Dict
+
+from dotenv import load_dotenv
+from openai import OpenAI
+
+from .ob_prompts import DEFAULT_ROLE, ROLE_PROMPTS
+
+# Configure logging
+LOG_FILE = Path(__file__).resolve().parents[2] / "logs" / "ob_agent.log"
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    handlers=[logging.FileHandler(LOG_FILE), logging.StreamHandler()],
+)
+logger = logging.getLogger(__name__)
+
+
+class OB:
+    """Base class for interacting with OB via OpenAI's API."""
+
+    def __init__(self, role: str = DEFAULT_ROLE) -> None:
+        """Initialise the OpenAI client and set the initial role."""
+        load_dotenv()
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise EnvironmentError("OPENAI_API_KEY not found in environment")
+        self.client = OpenAI(api_key=api_key)
+        self.role = role
+
+    def set_role(self, role: str) -> None:
+        """Switch between predefined OB roles."""
+        if role not in ROLE_PROMPTS:
+            raise ValueError(f"Unknown role: {role}")
+        self.role = role
+
+    def send_message(self, prompt: str) -> str:
+        """Send a message to OB and return the response text."""
+        system_prompt = ROLE_PROMPTS.get(self.role, ROLE_PROMPTS[DEFAULT_ROLE])
+        logger.info("Role: %s | Prompt: %s", self.role, prompt)
+        response = self.client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": prompt},
+            ],
+        )
+        content = response.choices[0].message["content"]
+        logger.info("Response: %s", content)
+        return content

--- a/fracmaster_toolbox/ob_agent/ob_prompts.py
+++ b/fracmaster_toolbox/ob_agent/ob_prompts.py
@@ -1,0 +1,24 @@
+"""Reusable prompts and role definitions for OB."""
+
+from __future__ import annotations
+
+DEFAULT_ROLE = "default"
+
+DEFAULT_PROMPT = (
+    "You are OB, a field assistant for FracMaster Toolbox. Your job is to "
+    "process engineering data and inject values into Excel packets. You do "
+    "not guess values—wait for instructions or provided data."
+)
+
+ROLE_PROMPTS = {
+    DEFAULT_ROLE: DEFAULT_PROMPT,
+    "packet_assistant": (
+        "You are OB acting as a Packet Assistant. Provide cell locations and "
+        "values based on supplied data."
+    ),
+    "perf_parser": (
+        "You are OB acting as a Perf Parser. Extract and summarize "
+        "performance metrics from provided sources."
+    ),
+}
+

--- a/fracmaster_toolbox/ob_agent/ob_runner.py
+++ b/fracmaster_toolbox/ob_agent/ob_runner.py
@@ -1,0 +1,25 @@
+"""CLI entry point for testing OB locally."""
+
+from __future__ import annotations
+
+import argparse
+
+from .ob_client import OB
+from .ob_prompts import ROLE_PROMPTS
+
+
+def main() -> None:
+    """Run the OB agent from the command line."""
+    parser = argparse.ArgumentParser(description="Send a prompt to OB")
+    parser.add_argument("prompt", help="Prompt to send to OB")
+    parser.add_argument(
+        "--role", default="default", choices=list(ROLE_PROMPTS.keys()), help="OB role to use"
+    )
+    args = parser.parse_args()
+
+    ob = OB(role=args.role)
+    print(ob.send_message(args.prompt))
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ cryptography==45.0.4
 customtkinter==5.2.2
 darkdetect==0.8.0
 et_xmlfile==2.0.0
+openai>=1.0.0
 openpyxl==3.1.5
 packaging==25.0
 pdfminer.six==20250327
@@ -17,6 +18,7 @@ pyinstaller-hooks-contrib==2025.5
 PyMuPDF==1.26.0
 pypdfium2==4.30.1
 pywin32-ctypes==0.2.3
+python-dotenv>=1.0.0
 setuptools==80.9.0
 PyQt5>=5.15
 pandas>=2.0

--- a/scripts/test_ob_agent.py
+++ b/scripts/test_ob_agent.py
@@ -1,0 +1,24 @@
+"""Simple test to verify OB responds using the API key from `.env`."""
+
+from __future__ import annotations
+
+import os
+
+from dotenv import load_dotenv
+
+from fracmaster_toolbox.ob_agent import OB
+
+
+def main() -> None:
+    """Send a basic prompt to OB and print the response."""
+    load_dotenv()
+    if not os.getenv("OPENAI_API_KEY"):
+        print("OPENAI_API_KEY not set; skipping OB agent test.")
+        return
+    ob = OB()
+    response = ob.send_message("Hello OB")
+    print("OB response:", response)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,9 @@ setup(
         'PyQt5',
         'pandas',
         'openpyxl',
-        'jsonschema'  # Add more here if needed
+        'jsonschema',  # Add more here if needed
+        'openai',
+        'python-dotenv'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
## Summary
- add `ob_agent` package with reusable prompts, OpenAI client wrapper, and CLI test runner
- log all OB interactions to `logs/ob_agent.log`
- document OB agent usage and add a simple test script

## Testing
- `pytest`
- `python scripts/test_ob_agent.py` *(no API key present, test skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688f2cddb27483248922a64efd14dc38