### PR TITLE
Refactor perf converter with OB integration

### DIFF
--- a/fracmaster_toolbox/ob_agent/__init__.py
+++ b/fracmaster_toolbox/ob_agent/__init__.py
@@ -1,5 +1,16 @@
 """OB agent package for managing prompts and OpenAI interactions."""
 
+from typing import Any, Dict
+import json
+
 from .ob_client import OB
 
-__all__ = ["OB"]
+
+def call_ob_agent(role: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Send a JSON payload to OB for the given role and return the parsed JSON response."""
+    ob = OB(role=role)
+    response = ob.send_message(json.dumps(payload))
+    return json.loads(response)
+
+
+__all__ = ["OB", "call_ob_agent"]

--- a/fracmaster_toolbox/ob_agent/ob_prompts.py
+++ b/fracmaster_toolbox/ob_agent/ob_prompts.py
@@ -38,6 +38,11 @@ ROLE_PROMPTS = {
         '  {"stage": 2, "top": 12561, "bottom": 12780, "plug": 12820}\n'
         "]"
     ),
+    "perf_converter_parser": (
+        "You are OB, the Perf Converter Parser. Convert completion procedure PDFs "
+        "into structured perf data for each well. Return JSON with a 'perf_data' "
+        "mapping well names to lists of [stage, plug, top, bottom] values."
+    ),
     "ticket_checker": (
         "You are OB, the Ticket Checker. Your job is to review stage ticket data for accuracy, "
         "flag inconsistencies, and report missing or incorrect information clearly."


### PR DESCRIPTION
## Summary
- rebuild perf-converter rows dynamically from job config
- call OB perf_converter_parser for PDF parsing with local fallback
- expose `call_ob_agent` and add `perf_converter_parser` role

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68900466537883248f64f17cd19708bd