### PR TITLE
feat: allow manual config reload in perf converter

### DIFF
--- a/fracmaster_toolbox/gui/main_gui.py
+++ b/fracmaster_toolbox/gui/main_gui.py
@@ -505,6 +505,10 @@ class FracMasterApp(ctk.CTk):
         upload_btn = ctk.CTkButton(tab, text="Upload Completion Procedure PDF", command=self.upload_pdf)
         upload_btn.grid(row=2, column=0, padx=10, pady=10, sticky="w")
 
+        # Manual config loader in case Job Setup tab didn't propagate
+        load_cfg_btn = ctk.CTkButton(tab, text="Load Config", command=self.load_config)
+        load_cfg_btn.grid(row=2, column=2, padx=10, pady=10, sticky="w")
+
         # Result box + Next/Export button
         self.next_button = ctk.CTkButton(tab, text="Proceed to Next Well’s Perf Data",
                                         command=self.show_next_well, state="disabled")

--- a/fracmaster_toolbox/ob_agent/ob_prompts.py
+++ b/fracmaster_toolbox/ob_agent/ob_prompts.py
@@ -39,9 +39,12 @@ ROLE_PROMPTS = {
         "]"
     ),
     "perf_converter_parser": (
-        "You are OB, the Perf Converter Parser. Convert completion procedure PDFs "
-        "into structured perf data for each well. Return JSON with a 'perf_data' "
-        "mapping well names to lists of [stage, plug, top, bottom] values."
+        "You are OB, the Perf Converter Parser. Given a completion procedure PDF and "
+        "a mapping of well names to page ranges and cluster counts, read the pages "
+        "and extract for each stage the plug depth plus the top and bottom "
+        "perforation depths. Parse the full pages with pdfplumber when needed and "
+        "filter out unrelated data. Return JSON with a 'perf_data' object mapping "
+        "each well to lists of [stage, plug, top, bottom] values."
     ),
     "ticket_checker": (
         "You are OB, the Ticket Checker. Your job is to review stage ticket data for accuracy, "


### PR DESCRIPTION
## Summary
- add manual `Load Config` button to Perf Converter so users can refresh wells if Job Setup config isn't picked up
- clarify `perf_converter_parser` OB prompt about page ranges and data to extract

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68905b2042c8832480a5969f1a8ff275